### PR TITLE
Fix go version issue in test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest]
         # When updating this, make sure to also update the
         # latest_go_version variable in internal/testing/runchecks.sh.
-        go-version: ["1.21.3"]
+        go-version: ["1.21.x"]
         include:
           - go-version: 1.21.x
             os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest]
         # When updating this, make sure to also update the
         # latest_go_version variable in internal/testing/runchecks.sh.
-        go-version: [1.21.x]
+        go-version: ["1.21.3"]
         include:
           - go-version: 1.20.x
             os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         # latest_go_version variable in internal/testing/runchecks.sh.
         go-version: ["1.21.3"]
         include:
-          - go-version: 1.20.x
+          - go-version: 1.21.x
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
https://github.com/golang/go/issues/57433

`slices` in the standard library has only existed since `go1.21`. This is the reason for the errors in the recent tests.

You have the following options:
- Use `golang.org/x/exp/slices` instead. This allows compatibility with go1.20 and below.
- Make sure to only use go1.21 in your tests.

This does not fix everything wrong with the tests. Most errors come from gocloud.dev/pubsub/drivertest. 

e.g.
```
    drivertest.go:564: nats: API error: code=400 err_code=10128 description=Stream name can not contain path separators
```
It looks like the issue has to do with t.Name() returning either the full or relative path as part of the name. 

There are a lot more issues than $27 is worth lol. Just a fun rabbit hole I saw on Replit.